### PR TITLE
Fixed product option update issue

### DIFF
--- a/cmd/app/controller/product.go
+++ b/cmd/app/controller/product.go
@@ -110,6 +110,7 @@ func (pc *ProductController) UpdateSpecificOption(id string, optionId string, po
 	if pc.db.Table("ProductOptions").
 		Where("Id = ? AND ProductId = ?", optionId, id).
 		Model(model.ProductOption{}).
+		Omit("Id").
 		Updates(&po).
 		RowsAffected == 0 && pc.db.Error == nil {
 		return gorm.ErrRecordNotFound


### PR DESCRIPTION
Product option update was always updating the ID with the product ID. I believe this due to the ORMs ability to detect ids from models and apply its smarts to it which seems buggy.
I now forcefully exclude the ID column from being updated as a workaround.